### PR TITLE
Updated suggested name to be compatible with Sketch 61

### DIFF
--- a/Auto-PDF-Exporter-nSlicer.sketchplugin/Contents/Sketch/main.js
+++ b/Auto-PDF-Exporter-nSlicer.sketchplugin/Contents/Sketch/main.js
@@ -141,7 +141,7 @@ function onRun(context) {
 			//var defaults = {exportToImages: true, exportImagesScale: 2.0} // true false
 			var filesToDelete = []
 			var pdf = PDFDocument.alloc().init()
-			var exportName = doc.hudClientName().replace(".sketch","");
+			var exportName = doc.cloudName().replace(".sketch","");
 			var saveLocation = promptSaveLocation(exportName)
 
 


### PR DESCRIPTION
Plugin crashes when using it with Sketch 61.
This change will fix it.
It seems to be in the suggested name of the pdf file. It now uses the CloudName property.