### PR TITLE
Change shortcut to an available one

### DIFF
--- a/Auto-PDF-Exporter-nSlicer.sketchplugin/Contents/Sketch/manifest.json
+++ b/Auto-PDF-Exporter-nSlicer.sketchplugin/Contents/Sketch/manifest.json
@@ -12,7 +12,7 @@
       {
         "script": "main.js",
         "handler": "onRun",
-        "shortcut": "cmd p",
+        "shortcut": "cmd shift p",
         "identifier": "autopdfexporter",
         "description": "Auto-export all '[S]' Prefix artboards to PDF, no slices needed!",
         "icon": "autoPDFexporter.png",


### PR DESCRIPTION
The shortcut was cmd p, but it seemed to be overridden by Sketch itself.
Updating to cmd shift p, it is available to the plugin again.